### PR TITLE
Create migration for error-logs table

### DIFF
--- a/.cursor/rules/scratchpad.mdc
+++ b/.cursor/rules/scratchpad.mdc
@@ -49,8 +49,21 @@ Create a Supabase migration file to create an error-logs table in the Recoup-cha
 3. Creating the migration file with proper structure
 
 ## Task Progress
-[ ] Explore workspace structure and locate Recoup-chat repo
-[ ] Find and analyze error-logs API in founder-dashboard repo
-[ ] Review existing migration files in Recoup-chat for patterns
-[ ] Create the error-logs migration file with proper columns and foreign keys
-[ ] Validate the migration structure
+[X] Explore workspace structure and locate Recoup-chat repo
+[X] Find and analyze error-logs API in founder-dashboard repo (found structure in database types)
+[X] Review existing migration files in Recoup-chat for patterns
+[X] Create the error-logs migration file with proper columns and foreign keys
+[X] Validate the migration structure
+
+## Findings:
+- Error logs table structure found in `types/database.types.ts`
+- Required columns: id, account_id, room_id, error_message, error_timestamp, error_type, last_message, raw_message (required), stack_trace, telegram_message_id, tool_name, created_at
+- Foreign keys: account_id -> accounts(id), room_id -> rooms(id)
+- Migration pattern: uuid ids, row level security, ON DELETE CASCADE, grants to anon/authenticated/service_role
+
+## Completed:
+- Created migration file: `supabase/migrations/20250621183810_create_error_logs_table.sql`
+- Includes all required columns with proper data types
+- Establishes foreign key relationships with accounts and rooms tables
+- Follows project patterns for permissions and triggers
+- Ready for deployment via Supabase migration system

--- a/.cursor/rules/scratchpad.mdc
+++ b/.cursor/rules/scratchpad.mdc
@@ -39,3 +39,18 @@ You should use the [scratchpad.md](mdc:scratchpad.md) file as a Scratchpad to or
 Also update the progress of the task in the Scratchpad when you finish a subtask.
 Especially when you finished a milestone, it will help to improve your depth of task accomplishment to use the Scratchpad to reflect and plan.
 The goal is to help you maintain a big picture as well as the progress of the task. Always refer to the Scratchpad when you plan the next step.
+
+# Current Task: Create error-logs Migration for Recoup-chat
+
+## Task Explanation
+Create a Supabase migration file to create an error-logs table in the Recoup-chat repository by:
+1. Checking the error-logs API in founder-dashboard repo to understand required columns
+2. Referencing existing migration files in Recoup-chat repo for foreign key patterns
+3. Creating the migration file with proper structure
+
+## Task Progress
+[ ] Explore workspace structure and locate Recoup-chat repo
+[ ] Find and analyze error-logs API in founder-dashboard repo
+[ ] Review existing migration files in Recoup-chat for patterns
+[ ] Create the error-logs migration file with proper columns and foreign keys
+[ ] Validate the migration structure

--- a/supabase/migrations/20250621183810_create_error_logs_table.sql
+++ b/supabase/migrations/20250621183810_create_error_logs_table.sql
@@ -1,0 +1,79 @@
+-- Create error_logs table for logging application errors
+create table "public"."error_logs" (
+    "id" uuid not null default gen_random_uuid(),
+    "account_id" uuid,
+    "room_id" uuid,
+    "error_message" text,
+    "error_timestamp" timestamp with time zone,
+    "error_type" text,
+    "last_message" text,
+    "raw_message" text not null,
+    "stack_trace" text,
+    "telegram_message_id" bigint,
+    "tool_name" text,
+    "created_at" timestamp with time zone not null default now()
+);
+
+alter table "public"."error_logs" enable row level security;
+
+CREATE UNIQUE INDEX error_logs_pkey ON public.error_logs USING btree (id);
+
+alter table "public"."error_logs" add constraint "error_logs_pkey" PRIMARY KEY using index "error_logs_pkey";
+
+-- Add foreign key constraints
+alter table "public"."error_logs" add constraint "error_logs_account_id_fkey" FOREIGN KEY (account_id) REFERENCES accounts(id) ON DELETE CASCADE not valid;
+
+alter table "public"."error_logs" validate constraint "error_logs_account_id_fkey";
+
+alter table "public"."error_logs" add constraint "error_logs_room_id_fkey" FOREIGN KEY (room_id) REFERENCES rooms(id) ON DELETE CASCADE not valid;
+
+alter table "public"."error_logs" validate constraint "error_logs_room_id_fkey";
+
+-- Grant permissions to different roles
+grant delete on table "public"."error_logs" to "anon";
+
+grant insert on table "public"."error_logs" to "anon";
+
+grant references on table "public"."error_logs" to "anon";
+
+grant select on table "public"."error_logs" to "anon";
+
+grant trigger on table "public"."error_logs" to "anon";
+
+grant truncate on table "public"."error_logs" to "anon";
+
+grant update on table "public"."error_logs" to "anon";
+
+grant delete on table "public"."error_logs" to "authenticated";
+
+grant insert on table "public"."error_logs" to "authenticated";
+
+grant references on table "public"."error_logs" to "authenticated";
+
+grant select on table "public"."error_logs" to "authenticated";
+
+grant trigger on table "public"."error_logs" to "authenticated";
+
+grant truncate on table "public"."error_logs" to "authenticated";
+
+grant update on table "public"."error_logs" to "authenticated";
+
+grant delete on table "public"."error_logs" to "service_role";
+
+grant insert on table "public"."error_logs" to "service_role";
+
+grant references on table "public"."error_logs" to "service_role";
+
+grant select on table "public"."error_logs" to "service_role";
+
+grant trigger on table "public"."error_logs" to "service_role";
+
+grant truncate on table "public"."error_logs" to "service_role";
+
+grant update on table "public"."error_logs" to "service_role";
+
+-- Add updated_at trigger
+CREATE TRIGGER set_updated_at
+    BEFORE UPDATE ON error_logs
+    FOR EACH ROW
+    EXECUTE FUNCTION trigger_set_updated_at();


### PR DESCRIPTION
A new Supabase migration file, `supabase/migrations/20250621183810_create_error_logs_table.sql`, was created to define the `error_logs` table.

*   The table schema, including columns such as `id`, `account_id`, `room_id`, `error_message`, `raw_message` (required), and `created_at`, was derived from the `error_logs` definition found in `types/database.types.ts`.
*   Foreign key constraints were established for `account_id` referencing `accounts(id)` and `room_id` referencing `rooms(id)`.
*   Row Level Security was enabled, and appropriate permissions were granted to `anon`, `authenticated`, and `service_role` roles. An `updated_at` trigger was also added.
*   These structural and security elements were implemented by referencing patterns found in existing migration files within the `Recoup-chat` repository.
*   The table was explicitly named `error_logs` (using underscores) to adhere to SQL naming conventions and match existing type definitions.