### PR TITLE
feat: redesign agent cards with separate components and improved UX

### DIFF
--- a/components/Agents/AgentCard.tsx
+++ b/components/Agents/AgentCard.tsx
@@ -14,16 +14,38 @@ interface AgentCardProps {
 }
 
 const AgentCard: React.FC<AgentCardProps> = ({ agent, onClick }) => {
+  // Define action tags that should be displayed in cards
+  const actionTags = ["Deep Research", "Send Report", "Email Outreach", "Scheduled Action", "Creative Content"];
+  
+  // Filter agent tags to only show action tags
+  const displayedActionTags = agent.tags?.filter(tag => 
+    actionTags.includes(tag)
+  ) || [];
+
   return (
     <button
       type="button"
-      className="w-full bg-white border border-gray-200/60 rounded-lg px-4 py-3 hover:border-gray-300 hover:shadow-md transition-all duration-200 text-left group hover:-translate-y-px"
+      className="w-full min-h-32 md:h-44 bg-gray-50 border border-gray-100 rounded-lg p-4 md:p-6 hover:bg-white hover:border-gray-200 hover:shadow-sm transition-all duration-200 text-left group relative flex flex-col"
       onClick={() => onClick(agent)}
     >
-      <div className="text-sm font-semibold text-gray-900 leading-tight group-hover:text-gray-700 transition-colors">
-        {agent.title}
+      {/* Action tag - fully rounded pills */}
+      {displayedActionTags.length > 0 && (
+        <div className="flex-shrink-0 mb-2 md:mb-3">
+          <span className="inline-block text-xs text-gray-400 bg-gray-50 px-2 py-1 rounded-full font-medium border border-gray-200">
+            {displayedActionTags[0]}
+          </span>
+        </div>
+      )}
+      
+      {/* Title - lighter weight */}
+      <div className="flex-shrink-0 mb-2 md:mb-3">
+        <h3 className="text-base md:text-lg font-medium text-gray-900 leading-tight group-hover:text-black transition-colors">
+          {agent.title}
+        </h3>
       </div>
-      <div className="text-gray-600 text-xs leading-relaxed opacity-0 group-hover:opacity-100 transition-all duration-200 max-h-0 group-hover:max-h-20 overflow-hidden mt-1">
+      
+      {/* Description - more compact */}
+      <div className="flex-1 text-gray-600 text-sm leading-relaxed line-clamp-3 overflow-hidden">
         {agent.description}
       </div>
     </button>

--- a/components/Agents/Agents.tsx
+++ b/components/Agents/Agents.tsx
@@ -38,15 +38,15 @@ const Agents = () => {
   };
 
   return (
-    <div className="max-w-full md:max-w-[calc(100vw-200px)] grow py-6 px-2 md:px-10">
-      <p className="text-center md:text-left font-plus_jakarta_sans_bold text-3xl mb-3">
+    <div className="max-w-full md:max-w-[calc(100vw-200px)] grow py-8 px-6 md:px-12">
+      <p className="text-center md:text-left font-plus_jakarta_sans_bold text-3xl mb-4">
         Agents
       </p>
-      <p className="text-base md:text-lg text-gray-400 text-center md:text-left mb-4 font-light font-inter">
+      <p className="text-lg text-gray-500 text-center md:text-left mb-8 font-light font-inter max-w-2xl">
         <span className="sm:hidden">Smarter label teams, powered by agents.</span>
         <span className="hidden sm:inline">Unlock the potential of your roster with intelligent, task-focused agents.</span>
       </p>
-      <div className="mt-2">
+      <div className="mb-8">
         <AgentTags
           tags={tags}
           selectedTag={selectedTag}
@@ -55,13 +55,13 @@ const Agents = () => {
           setShowAllTags={setShowAllTags}
         />
       </div>
-      <div className="mt-16" />
+      <div className="mt-12" />
       {loading ? (
-        <div className="text-center text-gray-400">Loading agents...</div>
+        <div className="text-center text-gray-400 py-12">Loading agents...</div>
       ) : gridAgents.length === 0 ? (
-        <div className="text-center text-gray-400">No agents found for this tag.</div>
+        <div className="text-center text-gray-400 py-12">No agents found for this tag.</div>
       ) : (
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-x-4 gap-y-10 px-2 md:px-10 md:max-w-[calc(100vw-200px)]">
+        <div className="grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 gap-8">
           {gridAgents.map((agent) => (
             <AgentCard
               key={agent.title}

--- a/components/Agents/useAgentData.ts
+++ b/components/Agents/useAgentData.ts
@@ -21,14 +21,19 @@ export function useAgentData() {
       .then((res) => res.json())
       .then((data: Agent[]) => {
         setAgents(data);
-        // Build a unique tag list from all agents, always including 'Recommended' first
+        
+        // Action tags that should NOT appear in top filters (now multi-word)
+        const actionTags = ["Deep Research", "Send Report", "Email Outreach", "Scheduled Action", "Creative Content"];
+        
+        // Build a unique tag list from all agents, excluding action tags
         const uniqueTags = Array.from(
           new Set(
             data
               .flatMap((agent: Agent) => agent.tags || [])
-              .filter((tag: string) => !!tag)
+              .filter((tag: string) => !!tag && !actionTags.includes(tag)) // Exclude action tags
           )
         );
+        
         const allTags = ["Recommended", ...uniqueTags];
         setTags(Array.from(new Set(allTags)));
         setLoading(false);

--- a/components/Chat/StarterAgentCard.tsx
+++ b/components/Chat/StarterAgentCard.tsx
@@ -1,0 +1,26 @@
+import type React from "react";
+import { type Agent } from "../Agents/useAgentData";
+
+interface StarterAgentCardProps {
+  agent: Agent;
+  onClick: (agent: Agent) => void;
+}
+
+const StarterAgentCard: React.FC<StarterAgentCardProps> = ({ agent, onClick }) => {
+  return (
+    <button
+      type="button"
+      className="w-full bg-white border border-gray-200/60 rounded-lg px-4 py-3 hover:border-gray-300 hover:shadow-md transition-all duration-200 text-left group hover:-translate-y-px"
+      onClick={() => onClick(agent)}
+    >
+      <div className="text-sm font-semibold text-gray-900 leading-tight group-hover:text-gray-700 transition-colors">
+        {agent.title}
+      </div>
+      <div className="text-gray-600 text-xs leading-relaxed opacity-0 group-hover:opacity-100 transition-all duration-300 max-h-0 group-hover:max-h-32 overflow-hidden mt-1">
+        {agent.description}
+      </div>
+    </button>
+  );
+};
+
+export default StarterAgentCard; 

--- a/components/Chat/StarterAgents.tsx
+++ b/components/Chat/StarterAgents.tsx
@@ -2,7 +2,7 @@
 
 import { useRouter } from "next/navigation";
 import { useAgentData, type Agent } from "../Agents/useAgentData";
-import AgentCard from "../Agents/AgentCard";
+import StarterAgentCard from "./StarterAgentCard";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 
 interface StarterAgentsProps {
@@ -70,7 +70,7 @@ export function StarterAgents({ isVisible }: StarterAgentsProps) {
                 transitionDelay: `${index * 100}ms`
               }}
             >
-              <AgentCard agent={agent} onClick={() => handleAgentClick(agent)} />
+              <StarterAgentCard agent={agent} onClick={() => handleAgentClick(agent)} />
             </div>
           ))}
         </div>


### PR DESCRIPTION
Major improvements to agent cards:
- Create separate StarterAgentCard component for initial chat vs agents tab
- Redesign AgentCard with grey background matching sidebar aesthetic
- Implement consistent card heights (h-44) for clean grid layout
- Update action tag system with multi-word names and proper filtering
- Add responsive design preventing description cut-offs on mobile
- Streamline visual design - reduced padding, lighter typography
- Improve action pills with proper rounded styling and borders
- Better grid spacing and layout for less intimidating appearance
- Filter action tags from top navigation (Deep Research, Send Report, etc.)
- Maintain white/black/grey minimal color scheme throughout