### PR TITLE
Delete legacy artist segments before creation

### DIFF
--- a/lib/segments/createArtistSegments.ts
+++ b/lib/segments/createArtistSegments.ts
@@ -2,6 +2,7 @@ import getAccountSocials from "../supabase/accountSocials/getAccountSocials";
 import { selectSocialFans } from "../supabase/social_fans/selectSocialFans";
 import { generateSegments } from "./generateSegments";
 import { insertSegments } from "../supabase/segments/insertSegments";
+import { deleteSegments } from "../supabase/segments/deleteSegments";
 import { insertArtistSegments } from "../supabase/artist_segments/insertArtistSegments";
 import { Tables } from "@/types/database.types";
 import { successResponse, errorResponse } from "./createSegmentResponses";
@@ -42,7 +43,15 @@ export const createArtistSegments = async ({
       return errorResponse("Failed to generate segment names");
     }
 
-    // Step 4: Insert segments into the database
+    // Step 4: Delete existing segments for the artist
+    try {
+      await deleteSegments(artist_account_id);
+    } catch (error) {
+      console.warn("Warning: Failed to delete existing segments:", error);
+      // Continue with creating new segments even if deletion fails
+    }
+
+    // Step 5: Insert segments into the database
     const segmentsToInsert = segmentNames.map((name: string) => ({
       name,
       updated_at: new Date().toISOString(),
@@ -50,7 +59,7 @@ export const createArtistSegments = async ({
 
     const insertedSegments = await insertSegments(segmentsToInsert);
 
-    // Step 5: Associate segments with the artist
+    // Step 6: Associate segments with the artist
     const artistSegmentsToInsert = insertedSegments.map(
       (segment: Tables<"segments">) => ({
         artist_account_id,

--- a/lib/supabase/segments/deleteSegments.ts
+++ b/lib/supabase/segments/deleteSegments.ts
@@ -1,0 +1,45 @@
+import serverClient from "../serverClient";
+import { Tables } from "@/types/database.types";
+
+type Segment = Tables<"segments">;
+
+export const deleteSegments = async (
+  artist_account_id: string
+): Promise<Segment[]> => {
+  // First, get all segment_ids associated with the artist from artist_segments table
+  const { data: artistSegments, error: artistSegmentsError } = await serverClient
+    .from("artist_segments")
+    .select("segment_id")
+    .eq("artist_account_id", artist_account_id);
+
+  if (artistSegmentsError) {
+    console.error("Error fetching artist segments:", artistSegmentsError);
+    throw artistSegmentsError;
+  }
+
+  if (!artistSegments || artistSegments.length === 0) {
+    // No segments to delete
+    return [];
+  }
+
+  // Extract segment_ids
+  const segmentIds = artistSegments.map((as: { segment_id: string }) => as.segment_id);
+
+  // Delete the segments from the segments table
+  const { data, error } = await serverClient
+    .from("segments")
+    .delete()
+    .in("id", segmentIds)
+    .select();
+
+  if (error) {
+    console.error("Error deleting segments:", error);
+    throw error;
+  }
+
+  if (!data || data.length === 0) {
+    throw new Error(`No segments found with ids: ${segmentIds.join(", ")}`);
+  }
+
+  return data;
+};


### PR DESCRIPTION
Delete previous artist segments before generating new ones to prevent accumulation.

Previously, `createArtistSegments` would only insert new segments, leading to an accumulation of old, unused segments for an artist. This change ensures that all existing segments linked to an artist are removed before new ones are created, maintaining data hygiene.

---

[Slack Thread](https://voicefirsttech.slack.com/archives/C05QQQS3AH0/p1752285577548609?thread_ts=1752285577.548609&cid=C05QQQS3AH0)