### PR TITLE
fix(useArtistFromRoom): select newly fetched artist reliably

### DIFF
--- a/hooks/useArtistFromRoom.ts
+++ b/hooks/useArtistFromRoom.ts
@@ -37,10 +37,7 @@ export function useArtistFromRoom(roomId: string) {
         if (artist) {
           setSelectedArtist(artist);
         } else {
-          await getArtists();
-          const updatedArtistList = artists as ArtistRecord[];
-          const updatedArtist = updatedArtistList.find(a => a.account_id === data.artist_id);
-          if (updatedArtist) setSelectedArtist(updatedArtist);
+          await getArtists(data.artist_id);
         }
       } catch (error) {
         console.error("Error selecting artist for room:", error);


### PR DESCRIPTION
Pass artist_id to getArtists so it fetches the list and sets selectedArtist, removing the race condition when a shared chat’s artist is not yet in local state.