### PR TITLE
Fix: Allow stop button to work without text in input box

### DIFF
--- a/components/VercelChat/ChatInput.tsx
+++ b/components/VercelChat/ChatInput.tsx
@@ -40,13 +40,16 @@ export function ChatInput({
   const handleSend = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
 
-    if (input === "" || isDisabled || hasPendingUploads) return;
-
+    // Allow stop action regardless of input state
     if (isGeneratingResponse) {
       onStop();
-    } else {
-      onSendMessage(event);
+      return;
     }
+
+    // Only check input requirements for sending new messages
+    if (input === "" || isDisabled || hasPendingUploads) return;
+
+    onSendMessage(event);
   };
 
   return (


### PR DESCRIPTION
- Reorganized handleSend logic to check for isGeneratingResponse first
- Stop button now works immediately when streaming, regardless of input content
- Improved user experience by removing unnecessary input requirement for stopping