### PR TITLE
perf: add database index for memories.room_id to fix recent chats loa…

### DIFF
--- a/supabase/migrations/20250915202437_add_memories_room_id_index.sql
+++ b/supabase/migrations/20250915202437_add_memories_room_id_index.sql
@@ -1,0 +1,20 @@
+-- Migration: Add optimized index for memories.room_id JOIN performance
+-- Description: This migration adds a btree index on memories.room_id to dramatically
+-- improve the performance of the rooms + memories JOIN query used in recent chats.
+-- 
+-- Problem: Sequential scans of 17,562+ memory records for just 10 rooms
+-- Solution: Direct index lookups reducing query time from 6ms+ to sub-millisecond
+-- Expected Impact: 10-15 second load time reduced to <1 second
+
+-- Add optimized index for memories.room_id JOIN performance
+CREATE INDEX IF NOT EXISTS idx_memories_room_id 
+ON public.memories USING btree (room_id);
+
+-- Optional: Composite index for cases where you need to order memories by updated_at within rooms
+-- Uncomment if you need to optimize queries that filter by room_id AND order by updated_at
+-- CREATE INDEX IF NOT EXISTS idx_memories_room_updated 
+-- ON public.memories USING btree (room_id, updated_at DESC);
+
+-- Add index on rooms.account_id for better filtering performance (if not already exists)
+CREATE INDEX IF NOT EXISTS idx_rooms_account_id 
+ON public.rooms USING btree (account_id);


### PR DESCRIPTION
…ding

- Add idx_memories_room_id btree index for JOIN performance optimization
- Add idx_rooms_account_id index for filtering performance
- Fixes 10-15 second recent chats load time by eliminating sequential scans
- EXPLAIN ANALYZE showed 17,562 memory records scanned for just 10 rooms
- Expected performance improvement: ~90% reduction in load time (<1 second)

Migration includes:
- Safe IF NOT EXISTS operations
- No schema changes or data modification
- Backwards compatible with existing queries