### PR TITLE
feat: remove unused sharing arrays from public.files

### DIFF
--- a/supabase/migrations/20250916130000_remove_file_share_arrays.sql
+++ b/supabase/migrations/20250916130000_remove_file_share_arrays.sql
@@ -1,0 +1,13 @@
+-- Remove unused sharing arrays from public.files and related indexes
+
+-- Drop dependent indexes if they exist
+drop index if exists public.idx_files_shared_with_account_ids;
+drop index if exists public.idx_files_shared_with_artist_account_ids;
+
+-- Drop legacy sharing columns
+alter table "public"."files"
+  drop column if exists "shared_with_artist_account_ids",
+  drop column if exists "shared_with_account_ids",
+  drop column if exists "shared_with_all_artist_members";
+
+


### PR DESCRIPTION
- Drop legacy sharing columns: shared_with_artist_account_ids, shared_with_account_ids, and shared_with_all_artist_members.
- Remove dependent indexes to clean up the database schema.