### PR TITLE
fix: improve upload status messaging and reset behavior

### DIFF
--- a/hooks/useFilesManager.ts
+++ b/hooks/useFilesManager.ts
@@ -137,9 +137,14 @@ export default function useFilesManager(activePath?: string) {
       return;
     }
 
-    setStatus("Uploaded");
+    setStatus("Uploaded successfully");
     if (!selectedFile) setFile(null);
     await qc.invalidateQueries({ queryKey: ["files", ownerAccountId, artistAccountId] });
+
+    // Clear success status after 3 seconds to be ready for new uploads
+    setTimeout(() => {
+      setStatus("");
+    }, 3000);
   }
 
   return {


### PR DESCRIPTION
- Updated the upload status message to "Uploaded successfully" for clarity.
- Implemented a timeout to clear the success status after 3 seconds, enhancing user feedback during file uploads.