### PR TITLE
feat: add created_at column to agent_templates table

### DIFF
--- a/supabase/migrations/20250917173709_add_created_at_to_agent_templates.sql
+++ b/supabase/migrations/20250917173709_add_created_at_to_agent_templates.sql
@@ -1,0 +1,5 @@
+-- Add created_at column to agent_templates
+ALTER TABLE agent_templates
+  ADD COLUMN IF NOT EXISTS created_at timestamp with time zone NOT NULL DEFAULT now();
+
+


### PR DESCRIPTION
- Introduced a new column 'created_at' to the agent_templates table to track creation timestamps.
- The column is set to NOT NULL with a default value of the current timestamp.