### PR TITLE
feat: add toggle for agent visibility between public and private

### DIFF
--- a/components/Agents/Agents.tsx
+++ b/components/Agents/Agents.tsx
@@ -4,6 +4,7 @@ import AgentCard from "./AgentCard";
 import { useAgentData } from "./useAgentData";
 import type { Agent } from "./useAgentData";
 import CreateAgentButton from "./CreateAgentButton";
+import { Switch } from "@/components/ui/switch";
 
 const Agents = () => {
   const { push } = useRouter();
@@ -15,6 +16,8 @@ const Agents = () => {
     showAllTags,
     setShowAllTags,
     gridAgents,
+    isPrivate,
+    togglePrivate,
   } = useAgentData();
 
   const handleAgentClick = (agent: Agent) => {
@@ -27,7 +30,15 @@ const Agents = () => {
         <p className="text-left font-plus_jakarta_sans_bold text-3xl">
           Agents
         </p>
-        <CreateAgentButton />
+        <div className="flex items-center gap-4">
+          <div className="flex items-center gap-2">
+            <span className="text-sm text-gray-600 dark:text-gray-400">
+              {isPrivate ? "Private" : "Public"}
+            </span>
+            <Switch checked={isPrivate} onCheckedChange={() => togglePrivate()} />
+          </div>
+          <CreateAgentButton />
+        </div>
       </div>
       <p className="text-lg text-gray-500 text-left mb-4 font-light font-inter max-w-2xl">
         <span className="sm:hidden">

--- a/components/Agents/useAgentData.ts
+++ b/components/Agents/useAgentData.ts
@@ -19,6 +19,7 @@ export function useAgentData() {
   const [selectedTag, setSelectedTag] = useState("Recommended");
   const [tags, setTags] = useState<string[]>(["Recommended"]);
   const [showAllTags, setShowAllTags] = useState(false);
+  const [isPrivate, setIsPrivate] = useState(false);
   
   const { data, isPending } = useQuery<Agent[]>({
     queryKey: ["agent-templates"],
@@ -50,11 +51,15 @@ export function useAgentData() {
 
   const loading = isPending;
 
-  // Get all agents except the special card, filtered by the selected tag
+  // Toggle function to switch between public and private agent visibility
+  const togglePrivate = () => setIsPrivate(!isPrivate);
+
+  // Get all agents except the special card, filtered by the selected tag and public/private
   const filteredAgents = agents.filter(
     (agent) =>
       agent.title !== "Audience Segmentation" &&
-      (selectedTag === "Recommended" ? true : agent.tags?.includes(selectedTag))
+      (selectedTag === "Recommended" ? true : agent.tags?.includes(selectedTag)) &&
+      (isPrivate ? agent.is_private === true : agent.is_private !== true)
   );
   // Hide the "Audience Segmentation" card from UI - keep all other logic intact
   const gridAgents = filteredAgents;
@@ -67,5 +72,7 @@ export function useAgentData() {
     showAllTags,
     setShowAllTags,
     gridAgents,
+    isPrivate,
+    togglePrivate,
   };
 } 


### PR DESCRIPTION
- Introduced a switch to toggle between public and private agent visibility in the Agents component.
- Updated the useAgentData hook to manage the private state and filter agents accordingly.