### PR TITLE
🔧 Remove namespacing for beta AI SDK tools in getMcpTools function

### DIFF
--- a/lib/tools/getMcpTools.ts
+++ b/lib/tools/getMcpTools.ts
@@ -81,13 +81,13 @@ export function getMcpTools(): ToolSet {
     ...youtubeTools,
   };
 
-  // Handle potential namespacing issues with beta AI SDK
-  // Some models may try to call tools with 'default_api.' prefix
-  const namespacedTools: ToolSet = { ...tools };
-  Object.entries(tools).forEach(([key, tool]) => {
-    // Also register with default_api prefix for compatibility with beta AI SDK
-    namespacedTools[`default_api.${key}`] = tool;
-  });
+  // // Handle potential namespacing issues with beta AI SDK
+  // // Some models may try to call tools with 'default_api.' prefix
+  // const namespacedTools: ToolSet = { ...tools };
+  // Object.entries(tools).forEach(([key, tool]) => {
+  //   // Also register with default_api prefix for compatibility with beta AI SDK
+  //   namespacedTools[`default_api.${key}`] = tool;
+  // });
 
-  return namespacedTools;
+  return tools;
 }


### PR DESCRIPTION
- Commented out the namespacing logic that added 'default_api.' prefix to tool names
- Directly return tools without the prefix for improved compatibility

This change simplifies the tool registration process and resolves potential confusion with tool naming in the chat interface.