### PR TITLE
✨ Implement email sharing functionality for agent templates

### DIFF
--- a/app/api/agent-templates/route.ts
+++ b/app/api/agent-templates/route.ts
@@ -30,6 +30,7 @@ export async function POST(request: Request) {
       prompt,
       tags,
       isPrivate,
+      shareEmails,
       userId,
     }: {
       title: string;
@@ -37,6 +38,7 @@ export async function POST(request: Request) {
       prompt: string;
       tags: string[];
       isPrivate: boolean;
+      shareEmails?: string[];
       userId?: string | null;
     } = body;
 
@@ -46,6 +48,7 @@ export async function POST(request: Request) {
       prompt,
       tags,
       isPrivate,
+      shareEmails,
       userId,
     });
     return NextResponse.json(data, { status: 201 });
@@ -86,6 +89,7 @@ export async function PATCH(request: Request) {
       prompt,
       tags,
       isPrivate,
+      shareEmails,
     }: {
       id: string;
       userId: string;
@@ -94,6 +98,7 @@ export async function PATCH(request: Request) {
       prompt?: string;
       tags?: string[];
       isPrivate?: boolean;
+      shareEmails?: string[];
     } = body;
 
     if (!id || !userId) {
@@ -118,7 +123,7 @@ export async function PATCH(request: Request) {
     if (typeof tags !== "undefined") updateFields.tags = tags;
     if (typeof isPrivate !== "undefined") updateFields.is_private = isPrivate;
 
-    const data = await updateAgentTemplate(id, updateFields);
+    const data = await updateAgentTemplate(id, updateFields, shareEmails);
     return NextResponse.json(data);
   } catch (error) {
     console.error("Error updating agent template:", error);

--- a/lib/supabase/accountEmails/getAccountDetailsByEmails.ts
+++ b/lib/supabase/accountEmails/getAccountDetailsByEmails.ts
@@ -1,0 +1,25 @@
+import supabase from "@/lib/supabase/serverClient";
+import type { Tables } from "@/types/database.types";
+
+/**
+ * Get account_emails by email addresses
+ * @param emails Array of email addresses to query
+ * @returns Array of account_emails rows
+ */
+export default async function getAccountDetailsByEmails(
+  emails: string[]
+): Promise<Tables<"account_emails">[]> {
+  if (!Array.isArray(emails) || emails.length === 0) return [];
+
+  const { data, error } = await supabase
+    .from("account_emails")
+    .select("*")
+    .in("email", emails);
+
+  if (error) {
+    console.error("Error fetching account_emails by emails:", error);
+    return [];
+  }
+
+  return data || [];
+}

--- a/lib/supabase/agent_templates/createAgentTemplate.ts
+++ b/lib/supabase/agent_templates/createAgentTemplate.ts
@@ -1,4 +1,5 @@
 import supabase from "@/lib/supabase/serverClient";
+import { createAgentTemplateShares } from "./createAgentTemplateShares";
 
 export async function createAgentTemplate(params: {
   title: string;
@@ -30,37 +31,3 @@ export async function createAgentTemplate(params: {
 
   return data;
 }
-
-// Helper function to create agent template shares
-async function createAgentTemplateShares(templateId: string, emails: string[]) {
-  // Get user accounts by email from account_emails table
-  const { data: userEmails, error: usersError } = await supabase
-    .from("account_emails")
-    .select("account_id, email")
-    .in("email", emails);
-
-  if (usersError) throw usersError;
-
-  if (!userEmails || userEmails.length === 0) {
-    // If no users found, we could either throw an error or silently continue
-    // For now, we'll silently continue as the emails might be for future users
-    return;
-  }
-
-  // Create share records for found users
-  const sharesData = userEmails.map(userEmail => ({
-    template_id: templateId,
-    user_id: userEmail.account_id,
-  }));
-
-  const { error: sharesError } = await supabase
-    .from("agent_template_shares")
-    .upsert(sharesData, {
-      onConflict: "template_id,user_id",
-      ignoreDuplicates: true
-    });
-
-  if (sharesError) throw sharesError;
-}
-
-

--- a/lib/supabase/agent_templates/createAgentTemplate.ts
+++ b/lib/supabase/agent_templates/createAgentTemplate.ts
@@ -6,6 +6,7 @@ export async function createAgentTemplate(params: {
   prompt: string;
   tags: string[];
   isPrivate: boolean;
+  shareEmails?: string[];
   userId?: string | null;
 }) {
   const { data, error } = await supabase
@@ -21,7 +22,45 @@ export async function createAgentTemplate(params: {
     .select("id, title, description, prompt, tags, creator, is_private, created_at, favorites_count")
     .single();
   if (error) throw error;
+
+  // Handle email sharing if agent is private and emails are provided
+  if (params.isPrivate && params.shareEmails && params.shareEmails.length > 0) {
+    await createAgentTemplateShares(data.id, params.shareEmails);
+  }
+
   return data;
+}
+
+// Helper function to create agent template shares
+async function createAgentTemplateShares(templateId: string, emails: string[]) {
+  // Get user accounts by email
+  const { data: users, error: usersError } = await supabase
+    .from("accounts")
+    .select("id, email")
+    .in("email", emails);
+
+  if (usersError) throw usersError;
+
+  if (!users || users.length === 0) {
+    // If no users found, we could either throw an error or silently continue
+    // For now, we'll silently continue as the emails might be for future users
+    return;
+  }
+
+  // Create share records for found users
+  const sharesData = users.map(user => ({
+    template_id: templateId,
+    user_id: user.id,
+  }));
+
+  const { error: sharesError } = await supabase
+    .from("agent_template_shares")
+    .upsert(sharesData, {
+      onConflict: "template_id,user_id",
+      ignoreDuplicates: true
+    });
+
+  if (sharesError) throw sharesError;
 }
 
 

--- a/lib/supabase/agent_templates/createAgentTemplate.ts
+++ b/lib/supabase/agent_templates/createAgentTemplate.ts
@@ -33,24 +33,24 @@ export async function createAgentTemplate(params: {
 
 // Helper function to create agent template shares
 async function createAgentTemplateShares(templateId: string, emails: string[]) {
-  // Get user accounts by email
-  const { data: users, error: usersError } = await supabase
-    .from("accounts")
-    .select("id, email")
+  // Get user accounts by email from account_emails table
+  const { data: userEmails, error: usersError } = await supabase
+    .from("account_emails")
+    .select("account_id, email")
     .in("email", emails);
 
   if (usersError) throw usersError;
 
-  if (!users || users.length === 0) {
+  if (!userEmails || userEmails.length === 0) {
     // If no users found, we could either throw an error or silently continue
     // For now, we'll silently continue as the emails might be for future users
     return;
   }
 
   // Create share records for found users
-  const sharesData = users.map(user => ({
+  const sharesData = userEmails.map(userEmail => ({
     template_id: templateId,
-    user_id: user.id,
+    user_id: userEmail.account_id,
   }));
 
   const { error: sharesError } = await supabase

--- a/lib/supabase/agent_templates/createAgentTemplateShares.ts
+++ b/lib/supabase/agent_templates/createAgentTemplateShares.ts
@@ -18,8 +18,6 @@ export async function createAgentTemplateShares(
   const userEmails = await getAccountDetailsByEmails(emails);
 
   if (userEmails.length === 0) {
-    // If no users found, we could either throw an error or silently continue
-    // For now, we'll silently continue as the emails might be for future users
     return;
   }
 

--- a/lib/supabase/agent_templates/createAgentTemplateShares.ts
+++ b/lib/supabase/agent_templates/createAgentTemplateShares.ts
@@ -1,0 +1,36 @@
+import getAccountDetailsByEmails from "@/lib/supabase/accountEmails/getAccountDetailsByEmails";
+import { insertAgentTemplateShares } from "./insertAgentTemplateShares";
+
+/**
+ * Create agent template shares for multiple email addresses
+ * @param templateId - The template ID to share
+ * @param emails - Array of email addresses to share with
+ */
+export async function createAgentTemplateShares(
+  templateId: string,
+  emails: string[]
+): Promise<void> {
+  if (!emails || emails.length === 0) {
+    return;
+  }
+
+  // Get user accounts by email using utility function
+  const userEmails = await getAccountDetailsByEmails(emails);
+
+  if (userEmails.length === 0) {
+    // If no users found, we could either throw an error or silently continue
+    // For now, we'll silently continue as the emails might be for future users
+    return;
+  }
+
+    // Create share records for found users (filter out null account_ids)
+    const sharesData = userEmails
+      .filter(userEmail => userEmail.account_id !== null)
+      .map(userEmail => ({
+        template_id: templateId,
+        user_id: userEmail.account_id!,
+      }));
+
+    // Insert shares using utility function
+    await insertAgentTemplateShares(sharesData);
+}

--- a/lib/supabase/agent_templates/deleteAgentTemplateShares.ts
+++ b/lib/supabase/agent_templates/deleteAgentTemplateShares.ts
@@ -1,0 +1,30 @@
+import supabase from "@/lib/supabase/serverClient";
+
+interface AgentTemplateShare {
+  id: string;
+  template_id: string;
+  user_id: string;
+  created_at: string;
+}
+
+/**
+ * Delete all agent template shares for a specific template
+ * @param templateId The template ID to delete shares for
+ * @returns Array of deleted share records
+ */
+export async function deleteAgentTemplateSharesByTemplateId(
+  templateId: string
+): Promise<AgentTemplateShare[]> {
+  const { data, error } = await supabase
+    .from("agent_template_shares")
+    .delete()
+    .eq("template_id", templateId)
+    .select();
+
+  if (error) {
+    console.error("Error deleting agent template shares:", error);
+    throw error;
+  }
+
+  return (data as AgentTemplateShare[]) || [];
+}

--- a/lib/supabase/agent_templates/insertAgentTemplateShares.ts
+++ b/lib/supabase/agent_templates/insertAgentTemplateShares.ts
@@ -1,0 +1,41 @@
+import supabase from "@/lib/supabase/serverClient";
+
+interface AgentTemplateShare {
+  id: string;
+  template_id: string;
+  user_id: string;
+  created_at: string;
+}
+
+interface AgentTemplateShareInsert {
+  template_id: string;
+  user_id: string;
+}
+
+/**
+ * Insert multiple agent template shares
+ * @param shares Array of share records to insert
+ * @returns Array of inserted share records
+ */
+export async function insertAgentTemplateShares(
+  shares: AgentTemplateShareInsert[]
+): Promise<AgentTemplateShare[]> {
+  if (!Array.isArray(shares) || shares.length === 0) {
+    return [];
+  }
+
+  const { data, error } = await supabase
+    .from("agent_template_shares")
+    .upsert(shares, {
+      onConflict: "template_id,user_id",
+      ignoreDuplicates: true
+    })
+    .select();
+
+  if (error) {
+    console.error("Error inserting agent template shares:", error);
+    throw error;
+  }
+
+  return (data as AgentTemplateShare[]) || [];
+}

--- a/lib/supabase/agent_templates/updateAgentTemplate.ts
+++ b/lib/supabase/agent_templates/updateAgentTemplate.ts
@@ -47,24 +47,24 @@ async function updateAgentTemplateShares(templateId: string, emails: string[]) {
 
   // Then create new shares if emails provided
   if (emails && emails.length > 0) {
-    // Get user accounts by email
-    const { data: users, error: usersError } = await supabase
-      .from("accounts")
-      .select("id, email")
+    // Get user accounts by email from account_emails table
+    const { data: userEmails, error: usersError } = await supabase
+      .from("account_emails")
+      .select("account_id, email")
       .in("email", emails);
 
     if (usersError) throw usersError;
 
-    if (!users || users.length === 0) {
+    if (!userEmails || userEmails.length === 0) {
       // If no users found, we could either throw an error or silently continue
       // For now, we'll silently continue as the emails might be for future users
       return;
     }
 
     // Create share records for found users
-    const sharesData = users.map(user => ({
+    const sharesData = userEmails.map(userEmail => ({
       template_id: templateId,
-      user_id: user.id,
+      user_id: userEmail.account_id,
     }));
 
     const { error: sharesError } = await supabase

--- a/lib/supabase/agent_templates/updateAgentTemplate.ts
+++ b/lib/supabase/agent_templates/updateAgentTemplate.ts
@@ -28,7 +28,6 @@ export async function updateAgentTemplate(
   if (error) throw error;
 
   // Handle email sharing updates if shareEmails is provided
-  // Note: userId is used for permission checking at the API level, not needed here
   if (typeof shareEmails !== "undefined") {
     await updateAgentTemplateShares(id, shareEmails);
   }

--- a/lib/supabase/agent_templates/updateAgentTemplate.ts
+++ b/lib/supabase/agent_templates/updateAgentTemplate.ts
@@ -1,4 +1,5 @@
 import supabase from "@/lib/supabase/serverClient";
+import { updateAgentTemplateShares } from "./updateAgentTemplateShares";
 
 export type AgentTemplateUpdates = {
   title?: string;
@@ -34,48 +35,3 @@ export async function updateAgentTemplate(
 
   return data;
 }
-
-// Helper function to update agent template shares
-async function updateAgentTemplateShares(templateId: string, emails: string[]) {
-  // First, delete existing shares
-  const { error: deleteError } = await supabase
-    .from("agent_template_shares")
-    .delete()
-    .eq("template_id", templateId);
-
-  if (deleteError) throw deleteError;
-
-  // Then create new shares if emails provided
-  if (emails && emails.length > 0) {
-    // Get user accounts by email from account_emails table
-    const { data: userEmails, error: usersError } = await supabase
-      .from("account_emails")
-      .select("account_id, email")
-      .in("email", emails);
-
-    if (usersError) throw usersError;
-
-    if (!userEmails || userEmails.length === 0) {
-      // If no users found, we could either throw an error or silently continue
-      // For now, we'll silently continue as the emails might be for future users
-      return;
-    }
-
-    // Create share records for found users
-    const sharesData = userEmails.map(userEmail => ({
-      template_id: templateId,
-      user_id: userEmail.account_id,
-    }));
-
-    const { error: sharesError } = await supabase
-      .from("agent_template_shares")
-      .upsert(sharesData, {
-        onConflict: "template_id,user_id",
-        ignoreDuplicates: true
-      });
-
-    if (sharesError) throw sharesError;
-  }
-}
-
-

--- a/lib/supabase/agent_templates/updateAgentTemplate.ts
+++ b/lib/supabase/agent_templates/updateAgentTemplate.ts
@@ -10,7 +10,8 @@ export type AgentTemplateUpdates = {
 
 export async function updateAgentTemplate(
   id: string,
-  updates: AgentTemplateUpdates
+  updates: AgentTemplateUpdates,
+  shareEmails?: string[]
 ) {
   const { data, error } = await supabase
     .from("agent_templates")
@@ -24,7 +25,57 @@ export async function updateAgentTemplate(
     )
     .single();
   if (error) throw error;
+
+  // Handle email sharing updates if shareEmails is provided
+  // Note: userId is used for permission checking at the API level, not needed here
+  if (typeof shareEmails !== "undefined") {
+    await updateAgentTemplateShares(id, shareEmails);
+  }
+
   return data;
+}
+
+// Helper function to update agent template shares
+async function updateAgentTemplateShares(templateId: string, emails: string[]) {
+  // First, delete existing shares
+  const { error: deleteError } = await supabase
+    .from("agent_template_shares")
+    .delete()
+    .eq("template_id", templateId);
+
+  if (deleteError) throw deleteError;
+
+  // Then create new shares if emails provided
+  if (emails && emails.length > 0) {
+    // Get user accounts by email
+    const { data: users, error: usersError } = await supabase
+      .from("accounts")
+      .select("id, email")
+      .in("email", emails);
+
+    if (usersError) throw usersError;
+
+    if (!users || users.length === 0) {
+      // If no users found, we could either throw an error or silently continue
+      // For now, we'll silently continue as the emails might be for future users
+      return;
+    }
+
+    // Create share records for found users
+    const sharesData = users.map(user => ({
+      template_id: templateId,
+      user_id: user.id,
+    }));
+
+    const { error: sharesError } = await supabase
+      .from("agent_template_shares")
+      .upsert(sharesData, {
+        onConflict: "template_id,user_id",
+        ignoreDuplicates: true
+      });
+
+    if (sharesError) throw sharesError;
+  }
 }
 
 

--- a/lib/supabase/agent_templates/updateAgentTemplateShares.ts
+++ b/lib/supabase/agent_templates/updateAgentTemplateShares.ts
@@ -20,8 +20,6 @@ export async function updateAgentTemplateShares(
     const userEmails = await getAccountDetailsByEmails(emails);
 
     if (userEmails.length === 0) {
-      // If no users found, we could either throw an error or silently continue
-      // For now, we'll silently continue as the emails might be for future users
       return;
     }
 

--- a/lib/supabase/agent_templates/updateAgentTemplateShares.ts
+++ b/lib/supabase/agent_templates/updateAgentTemplateShares.ts
@@ -1,0 +1,39 @@
+import getAccountDetailsByEmails from "@/lib/supabase/accountEmails/getAccountDetailsByEmails";
+import { deleteAgentTemplateSharesByTemplateId } from "./deleteAgentTemplateShares";
+import { insertAgentTemplateShares } from "./insertAgentTemplateShares";
+
+/**
+ * Update agent template shares - replaces existing shares with new ones
+ * @param templateId - The template ID to update shares for
+ * @param emails - Array of email addresses to share with (replaces existing)
+ */
+export async function updateAgentTemplateShares(
+  templateId: string,
+  emails: string[]
+): Promise<void> {
+  // First, delete existing shares
+  await deleteAgentTemplateSharesByTemplateId(templateId);
+
+  // Then create new shares if emails provided
+  if (emails && emails.length > 0) {
+    // Get user accounts by email using utility function
+    const userEmails = await getAccountDetailsByEmails(emails);
+
+    if (userEmails.length === 0) {
+      // If no users found, we could either throw an error or silently continue
+      // For now, we'll silently continue as the emails might be for future users
+      return;
+    }
+
+    // Create share records for found users (filter out null account_ids)
+    const sharesData = userEmails
+      .filter(userEmail => userEmail.account_id !== null)
+      .map(userEmail => ({
+        template_id: templateId,
+        user_id: userEmail.account_id!,
+      }));
+
+    // Insert shares using utility function
+    await insertAgentTemplateShares(sharesData);
+  }
+}


### PR DESCRIPTION
- Added `shareEmails` parameter to the agent template creation and update processes.
- Enhanced `createAgentTemplate` and `updateAgentTemplate` functions to handle email sharing.
- Introduced helper functions to manage the creation and updating of agent template shares in the database.
- Updated API routes to accommodate the new sharing feature, ensuring proper handling of private templates.