### PR TITLE
✨ Enhance agent template API to include shared emails for private tem…

### DIFF
--- a/lib/supabase/agent_templates/getAgentTemplateSharesByTemplateIds.ts
+++ b/lib/supabase/agent_templates/getAgentTemplateSharesByTemplateIds.ts
@@ -1,0 +1,30 @@
+import supabase from "@/lib/supabase/serverClient";
+
+interface AgentTemplateShare {
+  template_id: string;
+  user_id: string;
+  created_at: string;
+}
+
+/**
+ * Get all agent template shares for specific template IDs
+ * @param templateIds Array of template IDs to get shares for
+ * @returns Array of share records
+ */
+export async function getAgentTemplateSharesByTemplateIds(
+  templateIds: string[]
+): Promise<AgentTemplateShare[]> {
+  if (!Array.isArray(templateIds) || templateIds.length === 0) return [];
+
+  const { data, error } = await supabase
+    .from("agent_template_shares")
+    .select("template_id, user_id, created_at")
+    .in("template_id", templateIds);
+
+  if (error) {
+    console.error("Error fetching agent template shares:", error);
+    throw error;
+  }
+
+  return (data as AgentTemplateShare[]) || [];
+}

--- a/lib/supabase/agent_templates/getSharedEmailsForTemplates.ts
+++ b/lib/supabase/agent_templates/getSharedEmailsForTemplates.ts
@@ -1,0 +1,48 @@
+import getAccountEmails from "@/lib/supabase/accountEmails/getAccountEmails";
+import { getAgentTemplateSharesByTemplateIds } from "./getAgentTemplateSharesByTemplateIds";
+
+export async function getSharedEmailsForTemplates(templateIds: string[]): Promise<Record<string, string[]>> {
+  if (!templateIds || templateIds.length === 0) return {};
+
+  // Get all shares for these templates using existing utility
+  const shares = await getAgentTemplateSharesByTemplateIds(templateIds);
+
+  if (shares.length === 0) return {};
+
+  // Get all user IDs who have access to these templates
+  const userIds = [...new Set(shares.map(share => share.user_id))];
+
+  // Get emails for these users using existing utility
+  const emails = await getAccountEmails(userIds);
+
+  // Create a map of user_id to email
+  const userEmailMap: Record<string, string[]> = {};
+  emails.forEach(emailRecord => {
+    if (emailRecord.account_id && emailRecord.email) {
+      if (!userEmailMap[emailRecord.account_id]) {
+        userEmailMap[emailRecord.account_id] = [];
+      }
+      userEmailMap[emailRecord.account_id].push(emailRecord.email);
+    }
+  });
+
+  // Create the final map of template_id to emails
+  const emailMap: Record<string, string[]> = {};
+
+  shares.forEach(share => {
+    if (!emailMap[share.template_id]) {
+      emailMap[share.template_id] = [];
+    }
+
+    // Add all emails for this user
+    const userEmails = userEmailMap[share.user_id] || [];
+    emailMap[share.template_id].push(...userEmails);
+  });
+
+  // Remove duplicates for each template
+  Object.keys(emailMap).forEach(templateId => {
+    emailMap[templateId] = [...new Set(emailMap[templateId])];
+  });
+
+  return emailMap;
+}


### PR DESCRIPTION
…plates

- Integrated `getSharedEmailsForTemplates` to fetch shared emails for private agent templates.
- Updated the GET request handler to return templates with associated shared emails.
- Added new utility function `getAgentTemplateSharesByTemplateIds` to retrieve shares for specific template IDs.
- Created `getSharedEmailsForTemplates` to map user emails to their respective template shares.