### PR TITLE
✨ Enhance email sharing functionality in agent templates

### DIFF
--- a/components/Agents/AgentEditDialog.tsx
+++ b/components/Agents/AgentEditDialog.tsx
@@ -13,7 +13,7 @@ import CreateAgentForm from "./CreateAgentForm";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useUserProvider } from "@/providers/UserProvder";
 import type { AgentTemplateRow } from "@/types/AgentTemplates";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 
 interface AgentEditDialogProps {
   agent: AgentTemplateRow;
@@ -23,6 +23,7 @@ const AgentEditDialog: React.FC<AgentEditDialogProps> = ({ agent }) => {
   const [open, setOpen] = useState(false);
   const { userData } = useUserProvider();
   const queryClient = useQueryClient();
+  const [currentSharedEmails, setCurrentSharedEmails] = useState<string[]>(agent.shared_emails || []);
 
   const editTemplate = useMutation({
     mutationFn: async (values: {
@@ -33,6 +34,11 @@ const AgentEditDialog: React.FC<AgentEditDialogProps> = ({ agent }) => {
       isPrivate?: boolean;
       shareEmails?: string[];
     }) => {
+      // Combine existing emails (after removals) with new emails
+      const finalShareEmails = values.shareEmails && values.shareEmails.length > 0
+        ? [...currentSharedEmails, ...values.shareEmails]
+        : currentSharedEmails;
+
       const res = await fetch("/api/agent-templates", {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
@@ -44,7 +50,7 @@ const AgentEditDialog: React.FC<AgentEditDialogProps> = ({ agent }) => {
           prompt: values.prompt,
           tags: values.tags,
           isPrivate: values.isPrivate,
-          shareEmails: values.shareEmails,
+          shareEmails: finalShareEmails,
         }),
       });
       if (!res.ok) throw new Error("Failed to update template");
@@ -66,6 +72,17 @@ const AgentEditDialog: React.FC<AgentEditDialogProps> = ({ agent }) => {
   }) => {
     editTemplate.mutate(values);
   };
+
+  const handleExistingEmailsChange = (emails: string[]) => {
+    setCurrentSharedEmails(emails);
+  };
+
+  // Reset current shared emails when dialog opens or agent changes
+  useEffect(() => {
+    if (open) {
+      setCurrentSharedEmails(agent.shared_emails || []);
+    }
+  }, [open, agent.shared_emails]);
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>
@@ -90,6 +107,8 @@ const AgentEditDialog: React.FC<AgentEditDialogProps> = ({ agent }) => {
             isPrivate: agent.is_private,
             shareEmails: [],
           }}
+          existingSharedEmails={currentSharedEmails}
+          onExistingEmailsChange={handleExistingEmailsChange}
           submitLabel="Save changes"
         />
       </DialogContent>

--- a/components/Agents/CreateAgentForm.tsx
+++ b/components/Agents/CreateAgentForm.tsx
@@ -12,9 +12,11 @@ interface CreateAgentFormProps {
   isSubmitting?: boolean;
   initialValues?: Partial<CreateAgentFormData>;
   submitLabel?: string;
+  existingSharedEmails?: string[];
+  onExistingEmailsChange?: (emails: string[]) => void;
 }
 
-const CreateAgentForm = ({ onSubmit, isSubmitting, initialValues, submitLabel }: CreateAgentFormProps) => {
+const CreateAgentForm = ({ onSubmit, isSubmitting, initialValues, submitLabel, existingSharedEmails, onExistingEmailsChange }: CreateAgentFormProps) => {
   const form = useForm<CreateAgentFormData>({
     resolver: zodResolver(createAgentSchema),
     defaultValues: {
@@ -42,7 +44,7 @@ const CreateAgentForm = ({ onSubmit, isSubmitting, initialValues, submitLabel }:
     <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
       <FormFields form={form} />
       <TagSelector form={form} />
-      <PrivacySection form={form} />
+      <PrivacySection form={form} existingSharedEmails={existingSharedEmails} onExistingEmailsChange={onExistingEmailsChange} />
       <SubmitButton isSubmitting={isSubmitting} submitLabel={submitLabel} />
     </form>
   );

--- a/components/Agents/EmailShareInput.tsx
+++ b/components/Agents/EmailShareInput.tsx
@@ -1,16 +1,18 @@
 import { useState } from "react";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { Badge } from "@/components/ui/badge";
-import { X } from "lucide-react";
 import { isValidEmail } from "@/lib/utils/isValidEmail";
+import ExistingSharedEmailsList from "./ExistingSharedEmailsList";
+import NewEmailsList from "./NewEmailsList";
 
 interface EmailShareInputProps {
   emails: string[];
+  existingSharedEmails?: string[];
   onEmailsChange: (emails: string[]) => void;
+  onExistingEmailsChange?: (emails: string[]) => void;
 }
 
-const EmailShareInput = ({ emails, onEmailsChange }: EmailShareInputProps) => {
+const EmailShareInput = ({ emails, existingSharedEmails = [], onEmailsChange, onExistingEmailsChange }: EmailShareInputProps) => {
   const [inputValue, setInputValue] = useState("");
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
@@ -22,26 +24,35 @@ const EmailShareInput = ({ emails, onEmailsChange }: EmailShareInputProps) => {
 
   const addEmail = () => {
     const trimmedEmail = inputValue.trim().toLowerCase();
-    
+
     if (!trimmedEmail) return;
-    
+
     if (!isValidEmail(trimmedEmail)) {
       // You could add error handling here
       return;
     }
-    
-    if (emails.includes(trimmedEmail)) {
+
+    // Check if email already exists in either existing or new emails
+    if (emails.includes(trimmedEmail) || existingSharedEmails.includes(trimmedEmail)) {
       setInputValue("");
       return;
     }
-    
+
     onEmailsChange([...emails, trimmedEmail]);
     setInputValue("");
   };
 
-  const removeEmail = (emailToRemove: string) => {
+  const removeNewEmail = (emailToRemove: string) => {
     onEmailsChange(emails.filter(email => email !== emailToRemove));
   };
+
+  const removeExistingEmail = (emailToRemove: string) => {
+    if (onExistingEmailsChange) {
+      onExistingEmailsChange(existingSharedEmails.filter(email => email !== emailToRemove));
+    }
+  };
+
+  const hasAnyEmails = existingSharedEmails.length > 0 || emails.length > 0;
 
   return (
     <div className="space-y-2">
@@ -54,26 +65,17 @@ const EmailShareInput = ({ emails, onEmailsChange }: EmailShareInputProps) => {
         onChange={(e) => setInputValue(e.target.value)}
         onKeyDown={handleKeyDown}
       />
-      
-      {emails.length > 0 && (
-        <div className="flex flex-wrap gap-2 mt-2">
-          {emails.map((email) => (
-            <Badge
-              key={email}
-              variant="secondary"
-              className="flex items-center gap-1 pr-1"
-            >
-              {email}
-              <button
-                type="button"
-                onClick={() => removeEmail(email)}
-                className="ml-1 hover:bg-gray-200 rounded-full p-0.5"
-                aria-label={`Remove ${email}`}
-              >
-                <X className="h-3 w-3" />
-              </button>
-            </Badge>
-          ))}
+
+      {hasAnyEmails && (
+        <div className="space-y-3">
+          <ExistingSharedEmailsList
+            emails={existingSharedEmails}
+            onRemoveEmail={removeExistingEmail}
+          />
+          <NewEmailsList
+            emails={emails}
+            onRemoveEmail={removeNewEmail}
+          />
         </div>
       )}
     </div>

--- a/components/Agents/ExistingSharedEmailsList.tsx
+++ b/components/Agents/ExistingSharedEmailsList.tsx
@@ -1,0 +1,45 @@
+import { Badge } from "@/components/ui/badge";
+import { X, Users } from "lucide-react";
+
+interface ExistingSharedEmailsListProps {
+  emails: string[];
+  onRemoveEmail?: (email: string) => void;
+}
+
+const ExistingSharedEmailsList = ({ emails, onRemoveEmail }: ExistingSharedEmailsListProps) => {
+  if (emails.length === 0) return null;
+
+  return (
+    <div>
+      <div className="flex items-center gap-2 text-sm text-gray-600 mb-2">
+        <Users className="h-4 w-4" />
+        <span>Already shared with:</span>
+      </div>
+      <div className="flex flex-wrap gap-2">
+        {emails.map((email) => (
+          <Badge
+            key={`existing-${email}`}
+            variant="outline"
+            className="flex items-center gap-1 pr-1 bg-green-50 border-green-200 text-green-800"
+          >
+            {email}
+            <span className="text-xs opacity-70 mr-1">(shared)</span>
+            {onRemoveEmail && (
+              <button
+                type="button"
+                onClick={() => onRemoveEmail(email)}
+                className="ml-1 hover:bg-red-100 rounded-full p-0.5 opacity-70 hover:opacity-100"
+                aria-label={`Remove ${email} from shared list`}
+                title="Remove from shared list"
+              >
+                <X className="h-3 w-3" />
+              </button>
+            )}
+          </Badge>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default ExistingSharedEmailsList;

--- a/components/Agents/NewEmailsList.tsx
+++ b/components/Agents/NewEmailsList.tsx
@@ -1,0 +1,40 @@
+import { Badge } from "@/components/ui/badge";
+import { X } from "lucide-react";
+
+interface NewEmailsListProps {
+  emails: string[];
+  onRemoveEmail: (email: string) => void;
+}
+
+const NewEmailsList = ({ emails, onRemoveEmail }: NewEmailsListProps) => {
+  if (emails.length === 0) return null;
+
+  return (
+    <div>
+      <div className="text-sm text-gray-600 mb-2">
+        New shares to add:
+      </div>
+      <div className="flex flex-wrap gap-2">
+        {emails.map((email) => (
+          <Badge
+            key={`new-${email}`}
+            variant="secondary"
+            className="flex items-center gap-1 pr-1"
+          >
+            {email}
+            <button
+              type="button"
+              onClick={() => onRemoveEmail(email)}
+              className="ml-1 hover:bg-gray-200 rounded-full p-0.5"
+              aria-label={`Remove ${email}`}
+            >
+              <X className="h-3 w-3" />
+            </button>
+          </Badge>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default NewEmailsList;

--- a/components/Agents/PrivacySection.tsx
+++ b/components/Agents/PrivacySection.tsx
@@ -6,9 +6,11 @@ import EmailShareInput from "./EmailShareInput";
 
 interface PrivacySectionProps {
   form: UseFormReturn<CreateAgentFormData>;
+  existingSharedEmails?: string[];
+  onExistingEmailsChange?: (emails: string[]) => void;
 }
 
-const PrivacySection = ({ form }: PrivacySectionProps) => {
+const PrivacySection = ({ form, existingSharedEmails = [], onExistingEmailsChange }: PrivacySectionProps) => {
   const isPrivate = form.watch("isPrivate");
 
   return (
@@ -25,9 +27,11 @@ const PrivacySection = ({ form }: PrivacySectionProps) => {
       {isPrivate && (
         <EmailShareInput
           emails={form.watch("shareEmails") ?? []}
+          existingSharedEmails={existingSharedEmails}
           onEmailsChange={(emails) => {
             form.setValue("shareEmails", emails, { shouldDirty: true, shouldValidate: true });
           }}
+          onExistingEmailsChange={onExistingEmailsChange}
         />
       )}
     </>

--- a/types/AgentTemplates.ts
+++ b/types/AgentTemplates.ts
@@ -24,6 +24,8 @@ export type AgentTemplateRow = {
   updated_at: string | null;
   // computed for requesting user
   is_favourite?: boolean;
+  // emails the template is shared with (only for private templates)
+  shared_emails?: string[];
 };
 
 


### PR DESCRIPTION
- Updated `AgentEditDialog` to manage current shared emails and reset them when the dialog opens or the agent changes.
- Modified `CreateAgentForm` and `PrivacySection` to accept existing shared emails and handle changes.
- Improved `EmailShareInput` to differentiate between existing and new emails, allowing for better management of shared email addresses.
- Introduced new components `ExistingSharedEmailsList` and `NewEmailsList` for clearer email organization.