### PR TITLE
🔧 Fix model selection in 'More Models' dropdown

### DIFF
--- a/components/ModelSelect/ModelSelect.tsx
+++ b/components/ModelSelect/ModelSelect.tsx
@@ -12,12 +12,9 @@ import { usePaymentProvider } from "@/providers/PaymentProvider";
 import { organizeModels } from "@/lib/ai/organizeModels";
 import { getFeaturedModelConfig } from "@/lib/ai/featuredModels";
 import { useMemo } from "react";
-import useIsMobile from "@/hooks/useIsMobile";
-
 const ModelSelect = () => {
   const { model, setModel, availableModels } = useVercelChatContext();
   const { subscriptionActive } = usePaymentProvider();
-  const isMobile = useIsMobile();
 
   // Organize models into featured and other models
   const organizedModels = useMemo(() => {

--- a/components/ModelSelect/ModelSelect.tsx
+++ b/components/ModelSelect/ModelSelect.tsx
@@ -60,23 +60,12 @@ const ModelSelect = () => {
             {organizedModels.featuredModels.length > 0 && (
               <div className="my-1 h-px bg-border" />
             )}
-            <div className="relative">
-              <PromptInputModelSelect onValueChange={handleModelChange} value="">
-                <PromptInputModelSelectTrigger className="w-full justify-start px-3 py-2.5 text-sm font-medium text-muted-foreground hover:bg-accent hover:text-foreground rounded-lg border-none shadow-none bg-transparent [&>svg]:hidden">
-                  <span>More Models</span>
-                </PromptInputModelSelectTrigger>
-                <PromptInputModelSelectContent 
-                  className="min-w-[200px]" 
-                  side={isMobile ? "bottom" : "right"} 
-                  align="start" 
-                  sideOffset={8}
-                >
-                  {organizedModels.otherModels.map((model) => (
-                    <ModelSelectItem key={model.id} model={model} />
-                  ))}
-                </PromptInputModelSelectContent>
-              </PromptInputModelSelect>
+            <div className="px-3 py-2.5 text-sm font-medium text-muted-foreground">
+              More Models
             </div>
+            {organizedModels.otherModels.map((model) => (
+              <ModelSelectItem key={model.id} model={model} />
+            ))}
           </>
         )}
       </PromptInputModelSelectContent>


### PR DESCRIPTION
- Remove nested PromptInputModelSelect that was causing conflicts
- Convert 'More Models' from nested dropdown to simple section header
- All models now use single Select context with proper value handling
- Fixes issue where clicking models in expanded menu did nothing

Now clicking any model in the 'More Models' section properly selects it.