### PR TITLE
Add FileInfoDialog component and integrate it into FilesGridList

### DIFF
--- a/components/Files/FileInfoDialog.tsx
+++ b/components/Files/FileInfoDialog.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import type { FileRow } from "@/components/Files/types";
+
+type FileInfoDialogProps = {
+  file: FileRow | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+};
+
+export default function FileInfoDialog({ file, open, onOpenChange }: FileInfoDialogProps) {
+  if (!file) return null;
+  
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle className="truncate">{file.file_name}</DialogTitle>
+          <DialogDescription>File information</DialogDescription>
+        </DialogHeader>
+        <div className="mt-2 grid grid-cols-3 gap-y-2 text-sm">
+          <div className="text-muted-foreground">Type</div>
+          <div className="col-span-2">{file.is_directory ? "Folder" : "File"}</div>
+          <div className="text-muted-foreground">MIME</div>
+          <div className="col-span-2">{file.mime_type || "Unknown"}</div>
+          <div className="text-muted-foreground">Storage key</div>
+          <div className="col-span-2 break-all">{file.storage_key}</div>
+          <div className="text-muted-foreground">ID</div>
+          <div className="col-span-2 break-all">{file.id}</div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+

--- a/components/Files/FilesGridList.tsx
+++ b/components/Files/FilesGridList.tsx
@@ -1,10 +1,12 @@
 "use client";
 
-import { useCallback } from "react";
+import { useCallback, useState } from "react";
 import { PhotoProvider } from "react-photo-view";
 import "react-photo-view/dist/react-photo-view.css";
 import { FileRow } from "@/components/Files/types";
 import FileTile from "@/components/Files/FileTile";
+import getFileVisual from "@/utils/getFileVisual";
+import FileInfoDialog from "./FileInfoDialog";
 
 type FilesGridListProps = {
   files: FileRow[];
@@ -27,6 +29,8 @@ export default function FilesGridList({
   lastClickedIndex,
   onSelectionChange
 }: FilesGridListProps) {
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [dialogInfoFile, setDialogInfoFile] = useState<FileRow | null>(null);
 
   const handleFileClick = useCallback((file: FileRow, index: number, event: React.MouseEvent) => {
     event.stopPropagation(); // Prevent triggering clearSelection
@@ -56,6 +60,13 @@ export default function FilesGridList({
     } else {
       // Regular click: single selection
       onSelectionChange(new Set([file.id]), index);
+      
+      // Open dialog for non-image, non-directory files
+      const visual = getFileVisual(file.file_name, file.mime_type ?? null);
+      if (!file.is_directory && visual.icon !== "image") {
+        setDialogInfoFile(file);
+        setDialogOpen(true);
+      }
     }
   }, [selectedFiles, lastClickedIndex, files, onSelectionChange]);
 
@@ -89,6 +100,14 @@ export default function FilesGridList({
           );
         })}
       </div>
+      <FileInfoDialog 
+        file={dialogInfoFile} 
+        open={dialogOpen} 
+        onOpenChange={(open: boolean) => {
+          setDialogOpen(open);
+          if (!open) setDialogInfoFile(null);
+        }} 
+      />
     </PhotoProvider>
   );
 }


### PR DESCRIPTION
- Created a new FileInfoDialog component to display detailed information about selected files.
- Integrated FileInfoDialog into FilesGridList, allowing users to view file details on click for non-image, non-directory files.
- Added state management for dialog visibility and selected file information.