### PR TITLE
feat: add file update API endpoint with refactored utilities

### DIFF
--- a/app/api/files/update/route.ts
+++ b/app/api/files/update/route.ts
@@ -1,0 +1,85 @@
+import { NextResponse } from "next/server";
+import isValidStorageKey from "@/utils/isValidStorageKey";
+import { getFileByStorageKey } from "@/lib/supabase/files/getFileByStorageKey";
+import { uploadFileByKey } from "@/lib/supabase/storage/uploadFileByKey";
+import { updateFileSizeBytes } from "@/lib/supabase/files/updateFileSizeBytes";
+
+export async function POST(req: Request) {
+  try {
+    const body = await req.json();
+    const { storageKey, content, mimeType, ownerAccountId, artistAccountId } = body;
+
+    // Validate required fields
+    if (!storageKey || !isValidStorageKey(storageKey)) {
+      return NextResponse.json(
+        { error: "Invalid or missing storage key" },
+        { status: 400 }
+      );
+    }
+
+    if (typeof content !== "string") {
+      return NextResponse.json(
+        { error: "Content must be a string" },
+        { status: 400 }
+      );
+    }
+
+    if (!ownerAccountId || !artistAccountId) {
+      return NextResponse.json(
+        { error: "Missing ownerAccountId or artistAccountId" },
+        { status: 400 }
+      );
+    }
+
+    // Check if file exists and user has permission
+    const fileRecord = await getFileByStorageKey(storageKey);
+
+    if (!fileRecord) {
+      return NextResponse.json(
+        { error: "File not found" },
+        { status: 404 }
+      );
+    }
+
+    // Verify ownership
+    if (
+      fileRecord.owner_account_id !== ownerAccountId ||
+      fileRecord.artist_account_id !== artistAccountId
+    ) {
+      return NextResponse.json(
+        { error: "Permission denied" },
+        { status: 403 }
+      );
+    }
+
+    // Convert text content to Blob
+    const blob = new Blob([content], { type: mimeType || "text/plain" });
+    const file = new File([blob], storageKey.split("/").pop() || "file", {
+      type: mimeType || "text/plain",
+    });
+
+    // Upload to Supabase storage (upsert overwrites existing file)
+    await uploadFileByKey(storageKey, file, {
+      contentType: mimeType || "text/plain",
+      upsert: true,
+    });
+
+    // Update size_bytes in files table
+    const sizeBytes = new TextEncoder().encode(content).length;
+    try {
+      await updateFileSizeBytes(fileRecord.id, sizeBytes);
+    } catch (error) {
+      console.error("Failed to update file size:", error);
+      // Don't fail the request if only metadata update fails
+    }
+
+    return NextResponse.json(
+      { success: true, storageKey, sizeBytes },
+      { status: 200 }
+    );
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Unknown error";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}
+

--- a/app/api/storage/upload-by-key/route.ts
+++ b/app/api/storage/upload-by-key/route.ts
@@ -1,14 +1,6 @@
 import { NextResponse } from "next/server";
-import supabase from "@/lib/supabase/serverClient";
-import { SUPABASE_STORAGE_BUCKET } from "@/lib/consts";
-
-function isValidKey(key: string): boolean {
-  if (!key || key.length > 1024) return false;
-  if (key.startsWith("/")) return false;
-  if (key.includes("..")) return false;
-  if (key.includes("\\")) return false;
-  return true;
-}
+import { isValidStorageKey } from "@/utils/isValidStorageKey";
+import { uploadFileByKey } from "@/lib/supabase/storage/uploadFileByKey";
 
 export async function POST(req: Request) {
   try {
@@ -16,7 +8,7 @@ export async function POST(req: Request) {
     const key = formData.get("key");
     const file = formData.get("file");
 
-    if (typeof key !== "string" || !isValidKey(key)) {
+    if (typeof key !== "string" || !isValidStorageKey(key)) {
       return NextResponse.json({ error: "Invalid or missing key" }, { status: 400 });
     }
 
@@ -24,17 +16,10 @@ export async function POST(req: Request) {
       return NextResponse.json({ error: "Missing file" }, { status: 400 });
     }
 
-    const { error: uploadError } = await supabase
-      .storage
-      .from(SUPABASE_STORAGE_BUCKET)
-      .upload(key, file, {
-        contentType: file.type || "application/octet-stream",
-        upsert: false,
-      });
-
-    if (uploadError) {
-      return NextResponse.json({ error: uploadError.message }, { status: 500 });
-    }
+    await uploadFileByKey(key, file, {
+      contentType: file.type || "application/octet-stream",
+      upsert: false,
+    });
 
     return NextResponse.json({ path: key }, { status: 201 });
   } catch (err) {

--- a/lib/supabase/files/getFileByStorageKey.ts
+++ b/lib/supabase/files/getFileByStorageKey.ts
@@ -1,0 +1,27 @@
+import supabase from "@/lib/supabase/serverClient";
+
+type FilePermission = {
+  id: string;
+  owner_account_id: string;
+  artist_account_id: string;
+};
+
+/**
+ * Get file metadata by storage key for permission validation
+ */
+export async function getFileByStorageKey(
+  storageKey: string
+): Promise<FilePermission | null> {
+  const { data, error } = await supabase
+    .from("files")
+    .select("id, owner_account_id, artist_account_id")
+    .eq("storage_key", storageKey)
+    .single();
+
+  if (error || !data) {
+    return null;
+  }
+
+  return data;
+}
+

--- a/lib/supabase/files/updateFileSizeBytes.ts
+++ b/lib/supabase/files/updateFileSizeBytes.ts
@@ -1,0 +1,19 @@
+import supabase from "@/lib/supabase/serverClient";
+
+/**
+ * Update file size in bytes in the files table
+ */
+export async function updateFileSizeBytes(
+  fileId: string,
+  sizeBytes: number
+): Promise<void> {
+  const { error } = await supabase
+    .from("files")
+    .update({ size_bytes: sizeBytes })
+    .eq("id", fileId);
+
+  if (error) {
+    throw new Error(`Failed to update file size: ${error.message}`);
+  }
+}
+

--- a/lib/supabase/storage/uploadFileByKey.ts
+++ b/lib/supabase/storage/uploadFileByKey.ts
@@ -1,0 +1,29 @@
+import supabase from "@/lib/supabase/serverClient";
+import { SUPABASE_STORAGE_BUCKET } from "@/lib/consts";
+
+/**
+ * Upload file to Supabase storage by key
+ * @param key Storage key path
+ * @param file File or Blob to upload
+ * @param options Upload options including upsert
+ */
+export async function uploadFileByKey(
+  key: string,
+  file: File | Blob,
+  options: {
+    contentType?: string;
+    upsert?: boolean;
+  } = {}
+): Promise<void> {
+  const { error } = await supabase.storage
+    .from(SUPABASE_STORAGE_BUCKET)
+    .upload(key, file, {
+      contentType: options.contentType || "application/octet-stream",
+      upsert: options.upsert ?? false,
+    });
+
+  if (error) {
+    throw new Error(`Failed to upload file: ${error.message}`);
+  }
+}
+

--- a/utils/isValidStorageKey.ts
+++ b/utils/isValidStorageKey.ts
@@ -1,9 +1,12 @@
-export default function isValidStorageKey(key: string): boolean {
+/**
+ * Validates storage key format for Supabase storage
+ * Prevents path traversal and other security issues
+ */
+export function isValidStorageKey(key: string): boolean {
   if (!key || key.length > 1024) return false;
   if (key.startsWith("/")) return false;
   if (key.includes("..")) return false;
   if (key.includes("\\")) return false;
   return true;
 }
-
-
+export default isValidStorageKey;


### PR DESCRIPTION
- Create /api/files/update endpoint for editing text files
- Add shared isValidStorageKey utility to prevent duplication
- Add Supabase utils: getFileByStorageKey, updateFileSizeBytes, uploadFileByKey
- Refactor /api/storage/upload-by-key to use shared utilities
- Implement permission checks and ownership validation
- Update file content with upsert and sync metadata (size_bytes)